### PR TITLE
Revert "Merge pull request #9 from gynzy/TR3X-1327"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ To install this package:
 npm install --save-dev git+ssh://git@github.com:gynzy/gynzy-conventions.git
 ```
 
+This might produce warnings about peers required by this package:
+
+```
+npm WARN gynzy-conventions@0.0.1 requires a peer of eslint@^4.13.1 but none is installed. You must install peer dependencies yourself.
+```
+Install each of these to resolve this, otherwise ESLint might not work properly:
+
+```
+npm install --save-dev eslint
+npm install --save-dev prettier
+npm install --save-dev eslint-plugin-ava
+...
+```
+
 ## Integrating Configs
 To integrate an ESLint configuration of this repository in a _child_ repo, add a `.eslintrc.js` file containing:
 ```js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gynzy-conventions",
-  "version": "0.0.5",
+  "version": "0.0.4",
   "description": "Code conventions and lint configs for the Raptor squad",
   "private": true,
   "repository": {
@@ -11,11 +11,11 @@
   "files": [
     "configs/*"
   ],
-  "devDependencies": {
-    "eslint": "4.13.1",
-    "eslint-config-prettier": "2.9.0",
-    "eslint-plugin-ava": "4.4.0",
-    "eslint-plugin-prettier": "2.4.0",
-    "prettier": "1.9.2"
+  "peerDependencies": {
+    "eslint": "^4.13.1",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-ava": "^4.4.0",
+    "eslint-plugin-prettier": "^2.4.0",
+    "prettier": "^1.9.2"
   }
 }


### PR DESCRIPTION
Revert de changes om `devDependencies` te gebruiken in plaats van `peerDependencies` want `devDependencies` worden niet automatisch in de repo's geinstalleerd die hierop dependen.